### PR TITLE
Add HTML planner for shift breaks

### DIFF
--- a/break_app.html
+++ b/break_app.html
@@ -1,0 +1,464 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Shift Break Planner</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    :root {
+      font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+      color-scheme: light dark;
+    }
+
+    body {
+      margin: 0;
+      padding: 1.5rem;
+      background: radial-gradient(circle at 20% 20%, #f1f5f9, #dbeafe);
+      min-height: 100vh;
+      color: #0f172a;
+      display: flex;
+      justify-content: center;
+    }
+
+    .app {
+      width: min(960px, 100%);
+      background: rgba(255, 255, 255, 0.85);
+      border-radius: 1rem;
+      box-shadow: 0 20px 40px rgba(15, 23, 42, 0.15);
+      padding: 2rem 2.5rem 3rem;
+      backdrop-filter: blur(6px);
+    }
+
+    h1 {
+      margin-top: 0;
+      text-align: center;
+      font-size: clamp(1.8rem, 4vw, 2.4rem);
+      color: #1e293b;
+    }
+
+    p.guideline {
+      background: rgba(59, 130, 246, 0.08);
+      border-left: 4px solid #2563eb;
+      padding: 0.75rem 1rem;
+      border-radius: 0.75rem;
+      color: #1e3a8a;
+      line-height: 1.5;
+    }
+
+    form {
+      display: grid;
+      gap: 1rem;
+      margin: 2rem 0 2.5rem;
+    }
+
+    label {
+      display: flex;
+      flex-direction: column;
+      font-weight: 600;
+      color: #0f172a;
+      gap: 0.35rem;
+    }
+
+    input[type="time"] {
+      padding: 0.6rem 0.75rem;
+      border-radius: 0.6rem;
+      border: 1px solid #cbd5f5;
+      font-size: 1rem;
+      background: #f8fafc;
+      color: inherit;
+    }
+
+    button,
+    .status-pill {
+      border: none;
+      border-radius: 999px;
+      padding: 0.65rem 1.6rem;
+      font-size: 1rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    button {
+      background: linear-gradient(135deg, #2563eb, #4338ca);
+      color: #f8fafc;
+      box-shadow: 0 10px 24px rgba(37, 99, 235, 0.3);
+    }
+
+    button:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 12px 28px rgba(79, 70, 229, 0.25);
+    }
+
+    button.secondary {
+      background: linear-gradient(135deg, #0ea5e9, #0284c7);
+      margin-right: 0.75rem;
+    }
+
+    button.destructive {
+      background: linear-gradient(135deg, #ef4444, #dc2626);
+    }
+
+    .clock {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      font-size: clamp(2.5rem, 5vw, 3.2rem);
+      font-weight: 700;
+      letter-spacing: 0.2rem;
+      color: #1d4ed8;
+      margin-bottom: 1.75rem;
+    }
+
+    .status {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 1.5rem;
+    }
+
+    .status-pill {
+      background: rgba(34, 197, 94, 0.15);
+      color: #166534;
+      box-shadow: inset 0 0 0 1px rgba(22, 101, 52, 0.3);
+    }
+
+    .status-pill.break {
+      background: rgba(234, 179, 8, 0.18);
+      color: #92400e;
+      box-shadow: inset 0 0 0 1px rgba(146, 64, 14, 0.25);
+    }
+
+    .break-controls {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      align-items: center;
+    }
+
+    .schedule {
+      display: grid;
+      gap: 1rem;
+    }
+
+    .card {
+      background: rgba(248, 250, 252, 0.85);
+      border-radius: 0.9rem;
+      padding: 1.1rem 1.35rem;
+      box-shadow: 0 12px 24px rgba(15, 23, 42, 0.1);
+    }
+
+    .schedule-list {
+      list-style: none;
+      margin: 0.75rem 0 0;
+      padding: 0;
+      display: grid;
+      gap: 0.5rem;
+    }
+
+    .schedule-list li {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      background: rgba(59, 130, 246, 0.08);
+      border-radius: 0.75rem;
+      padding: 0.65rem 0.9rem;
+      color: #1d4ed8;
+      font-weight: 600;
+    }
+
+    .small-text {
+      font-size: 0.9rem;
+      color: #334155;
+      line-height: 1.45;
+    }
+
+    .highlight {
+      color: #2563eb;
+      font-weight: 700;
+    }
+
+    @media (max-width: 640px) {
+      body {
+        padding: 1rem;
+      }
+
+      .app {
+        padding: 1.5rem;
+      }
+
+      .break-controls {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      button {
+        width: 100%;
+        text-align: center;
+      }
+
+      .status {
+        gap: 1rem;
+        justify-content: center;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="app" aria-live="polite">
+    <h1>Vision-Friendly Shift Break Planner</h1>
+
+    <p class="guideline">
+      Ophthalmologists suggest the <span class="highlight">20-20-20</span> rule—look 20 feet away for 20 seconds every 20 minutes—to fight screen fatigue. This planner layers on restorative <span class="highlight">five-minute eye and posture breaks roughly once every hour</span>, while respecting your fixed 15-minute and 60-minute lunch breaks so that pauses never exceed half of your shift.
+    </p>
+
+    <div class="clock" role="timer" aria-live="polite" id="liveClock">--:--:--</div>
+
+    <section class="status">
+      <div class="status-pill" id="shiftStatus">Shift status: not set</div>
+      <div class="status-pill break" id="breakStatus">Not on break</div>
+    </section>
+
+    <form id="shiftForm">
+      <label>
+        Shift start time
+        <input type="time" id="startTime" required />
+      </label>
+      <label>
+        Shift end time
+        <input type="time" id="endTime" required />
+      </label>
+      <button type="submit">Generate break plan</button>
+    </form>
+
+    <section class="break-controls" aria-label="Manual break controls">
+      <button type="button" class="secondary" data-break="fifteen">Start 15-minute break</button>
+      <button type="button" class="secondary" data-break="lunch">Start 60-minute lunch</button>
+      <button type="button" class="destructive" id="endBreak">End current break</button>
+    </section>
+
+    <section class="schedule" id="schedule">
+      <article class="card" id="nextBreakCard">
+        <h2>Next suggested five-minute break</h2>
+        <p class="small-text" id="nextBreakInfo">Plan your shift to see the first suggested break.</p>
+      </article>
+
+      <article class="card">
+        <h2>Break schedule overview</h2>
+        <ul class="schedule-list" id="breakList" aria-live="polite"></ul>
+        <p class="small-text">
+          Five-minute breaks are spaced to keep your screen time below fatigue thresholds without surpassing 50% of your paid work hours. Tap a break entry as you take it to mark it complete.
+        </p>
+      </article>
+    </section>
+  </main>
+
+  <script>
+    const shiftForm = document.getElementById("shiftForm");
+    const startInput = document.getElementById("startTime");
+    const endInput = document.getElementById("endTime");
+    const liveClock = document.getElementById("liveClock");
+    const shiftStatus = document.getElementById("shiftStatus");
+    const breakStatus = document.getElementById("breakStatus");
+    const breakList = document.getElementById("breakList");
+    const nextBreakInfo = document.getElementById("nextBreakInfo");
+    const nextBreakCard = document.getElementById("nextBreakCard");
+    const endBreakButton = document.getElementById("endBreak");
+
+    let breakSchedule = [];
+    let currentBreak = null;
+
+    function updateClock() {
+      const now = new Date();
+      liveClock.textContent = now.toLocaleTimeString([], {
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+      });
+      highlightNextBreak(now);
+    }
+
+    setInterval(updateClock, 1000);
+    updateClock();
+
+    function parseTime(timeStr) {
+      const [hours, minutes] = timeStr.split(":").map(Number);
+      const now = new Date();
+      now.setHours(hours, minutes, 0, 0);
+      return now;
+    }
+
+    function addMinutes(date, minutes) {
+      return new Date(date.getTime() + minutes * 60000);
+    }
+
+    function formatTime(date) {
+      return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+    }
+
+    function createBreakSchedule(start, end) {
+      const schedule = [];
+      const totalMinutes = (end - start) / 60000;
+      const interval = 55; // 55 minutes on task, 5 minutes break
+      const breakLength = 5;
+
+      if (totalMinutes <= 0) {
+        return [];
+      }
+
+      let cursor = addMinutes(start, interval);
+      while (cursor < end) {
+        const breakEnd = addMinutes(cursor, breakLength);
+        if (breakEnd > end) {
+          break;
+        }
+        schedule.push({ start: new Date(cursor), end: breakEnd, completed: false });
+        cursor = addMinutes(cursor, interval);
+
+        const totalBreakMinutes = schedule.length * breakLength;
+        if (totalBreakMinutes > totalMinutes / 2) {
+          schedule.pop();
+          break;
+        }
+      }
+
+      return schedule;
+    }
+
+    function renderSchedule() {
+      breakList.innerHTML = "";
+
+      if (breakSchedule.length === 0) {
+        const empty = document.createElement("li");
+        empty.textContent = "No breaks scheduled yet.";
+        empty.style.justifyContent = "center";
+        empty.style.color = "#475569";
+        breakList.appendChild(empty);
+        nextBreakInfo.textContent = "No upcoming breaks—enter your shift to generate a plan.";
+        return;
+      }
+
+      breakSchedule.forEach((slot, index) => {
+        const item = document.createElement("li");
+        item.setAttribute("role", "button");
+        item.setAttribute("tabindex", "0");
+        item.dataset.index = index;
+
+        const timeLabel = document.createElement("span");
+        timeLabel.textContent = `${formatTime(slot.start)} - ${formatTime(slot.end)}`;
+
+        const status = document.createElement("span");
+        status.textContent = slot.completed ? "Completed" : "Pending";
+        status.style.color = slot.completed ? "#16a34a" : "#dc2626";
+
+        item.appendChild(timeLabel);
+        item.appendChild(status);
+
+        item.addEventListener("click", () => toggleBreakCompletion(index));
+        item.addEventListener("keypress", (event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            toggleBreakCompletion(index);
+          }
+        });
+
+        if (slot.completed) {
+          item.style.opacity = 0.6;
+        }
+
+        breakList.appendChild(item);
+      });
+
+      updateNextBreakText();
+    }
+
+    function toggleBreakCompletion(index) {
+      breakSchedule[index].completed = !breakSchedule[index].completed;
+      renderSchedule();
+    }
+
+    function updateNextBreakText() {
+      const upcoming = breakSchedule.find((slot) => !slot.completed && slot.start > new Date());
+      if (upcoming) {
+        nextBreakInfo.innerHTML = `Next five-minute break: <strong>${formatTime(upcoming.start)}</strong> to <strong>${formatTime(upcoming.end)}</strong>.`;
+      } else {
+        nextBreakInfo.textContent = "All scheduled five-minute breaks are complete.";
+      }
+    }
+
+    function highlightNextBreak(now) {
+      const card = nextBreakCard;
+      const upcoming = breakSchedule.find((slot) => now >= slot.start && now <= slot.end);
+      if (upcoming) {
+        card.style.boxShadow = "0 0 0 3px rgba(34,197,94,0.35)";
+        nextBreakInfo.innerHTML = `You're in a scheduled five-minute break until <strong>${formatTime(upcoming.end)}</strong>.`;
+      } else {
+        card.style.boxShadow = "0 12px 24px rgba(15, 23, 42, 0.1)";
+        updateNextBreakText();
+      }
+    }
+
+    function setShiftStatus(start, end) {
+      shiftStatus.textContent = `Shift: ${formatTime(start)} – ${formatTime(end)}`;
+    }
+
+    function startManualBreak(type) {
+      const descriptors = {
+        fifteen: { label: "On a 15-minute break", minutes: 15 },
+        lunch: { label: "On a 60-minute lunch", minutes: 60 },
+      };
+
+      const descriptor = descriptors[type];
+      if (!descriptor) return;
+
+      currentBreak = {
+        type,
+        end: addMinutes(new Date(), descriptor.minutes),
+      };
+      breakStatus.textContent = `${descriptor.label} until ${formatTime(currentBreak.end)}`;
+      breakStatus.classList.add("break");
+    }
+
+    function endManualBreak() {
+      currentBreak = null;
+      breakStatus.textContent = "Not on break";
+      breakStatus.classList.remove("break");
+    }
+
+    shiftForm.addEventListener("submit", (event) => {
+      event.preventDefault();
+      const startValue = startInput.value;
+      const endValue = endInput.value;
+
+      if (!startValue || !endValue) {
+        alert("Please enter both start and end times.");
+        return;
+      }
+
+      const start = parseTime(startValue);
+      let end = parseTime(endValue);
+
+      if (end <= start) {
+        end = addMinutes(end, 24 * 60);
+      }
+
+      breakSchedule = createBreakSchedule(start, end);
+      setShiftStatus(start, end);
+      renderSchedule();
+    });
+
+    document.querySelectorAll("button[data-break]").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        const type = btn.dataset.break;
+        startManualBreak(type);
+      });
+    });
+
+    endBreakButton.addEventListener("click", () => {
+      endManualBreak();
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone HTML break planner that calculates 5-minute eye breaks based on shift hours
- include live clock, next-break highlights, and manual controls for 15-minute and lunch breaks

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ccf7acce608325b74e135a0e0a9b3b